### PR TITLE
Use treeherder to get all builds for a revision instead of buildapi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ deps = [
     'mozillapulse',
     'mock',
     'requests',
+    'mozci',
 ]
 
 setup(name='trigger-bot',


### PR DESCRIPTION
All the tests are passing locally. r? @chmanchester 