### PR TITLE
Fix logging for handlers

### DIFF
--- a/triggerbot/tree_watcher.py
+++ b/triggerbot/tree_watcher.py
@@ -48,6 +48,7 @@ class TreeWatcher(object):
         self.auth = ldap_auth
         self.lower_trigger_limit = TreeWatcher.default_retry * TreeWatcher.per_push_failures
         self.log = logging.getLogger('trigger-bot')
+        logging.basicConfig()
         self.is_triggerbot_user = is_triggerbot_user
         self.global_trigger_count = 0
         self.treeherder_client = TreeherderClient()


### PR DESCRIPTION
I was getting the error:
    No handlers could be found for logger "trigger-bot"

Thought it would be useful to fix this, so that there are logs generated in case trigger-bot faces some error.